### PR TITLE
fixed issue 23

### DIFF
--- a/src/ParkitectNexus.Data/ObjectFactory.cs
+++ b/src/ParkitectNexus.Data/ObjectFactory.cs
@@ -1,4 +1,5 @@
-﻿using ParkitectNexus.Data.Game;
+﻿
+using ParkitectNexus.Data.Game;
 using ParkitectNexus.Data.Presenter;
 using ParkitectNexus.Data.Reporting;
 using ParkitectNexus.Data.Settings;
@@ -27,7 +28,7 @@ namespace ParkitectNexus.Data
             registry.For<ILogger>().Use<Logger>().Singleton();
 
             //repository settings
-            registry.For(typeof(IRepository<>)).Use(typeof(Repository<>));
+            registry.For(typeof(IRepository<>)).Singleton().Use(typeof(Repository<>)) ;
             registry.For<IRepositoryFactory>().Use<RepositoryFactory>();
 
             //used to send crash reports

--- a/src/ParkitectNexus.Data/Settings/Models/GameSettings.cs
+++ b/src/ParkitectNexus.Data/Settings/Models/GameSettings.cs
@@ -1,10 +1,13 @@
 // ParkitectNexusClient
 // Copyright 2016 Parkitect, Tim Potze
 
+using System;
+
 namespace ParkitectNexus.Data.Settings
 {
     public class GameSettings
     {
         public string InstallationPath { get; set; }
+        
     }
 }

--- a/src/ParkitectNexus.Data/Settings/Repository.cs
+++ b/src/ParkitectNexus.Data/Settings/Repository.cs
@@ -4,6 +4,8 @@ using ParkitectNexus.Data.Settings;
 using System.IO;
 using System;
 using Newtonsoft.Json;
+using StructureMap.TypeRules;
+using System.Collections.Generic;
 
 namespace ParkitectNexus.Data.Settings
 {
@@ -21,13 +23,11 @@ namespace ParkitectNexus.Data.Settings
             }
         }
 
-        public Repository(IPathResolver pathResolver)
+        public Repository(IPathResolver pathResolver, T model)
         {
-            
+            _model = model;
             _pathResolver = pathResolver;
-
-            _model = Activator.CreateInstance<T>();
-            _path = Path.Combine(pathResolver.AppData(),_model.GetType().Name + ".json");
+            _path = Path.Combine(pathResolver.AppData(), _model.GetType().Name + ".json");
             Load();
         }
 

--- a/src/ParkitectNexusClient/Settings/ClientSettings.cs
+++ b/src/ParkitectNexusClient/Settings/ClientSettings.cs
@@ -2,10 +2,9 @@
 // Copyright 2016 Parkitect, Tim Potze
 
 using ParkitectNexus.Data.Settings;
-
 namespace ParkitectNexus.Client.Settings
 {
-    public class ClientSettings
+    public class ClientSettings 
     {
         public bool BootOnNextRun { get; set; }
         public string DownloadOnNextRun { get; set; }


### PR DESCRIPTION
I'm not sure how this fixes the loading issue, but it does. I'm just guessing it's the way structuremap works with the dependency's.   For some reason I believe you can also shorten up how Presenters works. Can you double check this because i'm having a hard time believing that it would be this simple.

I also got rid of that nasty bit of Activator I used. 

Activator.CreateInstance<T>();

Singleton
IRepository - > model1
IRepository - > model2
...
IRepository - > model3
