### PR TITLE
bug fix API

### DIFF
--- a/src/ParkitectNexus.Data/Assets/AssetType.cs
+++ b/src/ParkitectNexus.Data/Assets/AssetType.cs
@@ -15,7 +15,7 @@ namespace ParkitectNexus.Data.Assets
         /// <summary>
         ///     A savegame.
         /// </summary>
-        [AssetInfo("text/plain")] Savegame,
+        [AssetInfo("text/plain")] Park,
 
         /// <summary>
         ///     A blueprint.

--- a/src/ParkitectNexus.Data/Assets/LocalAssetsRepository.cs
+++ b/src/ParkitectNexus.Data/Assets/LocalAssetsRepository.cs
@@ -42,8 +42,8 @@ namespace ParkitectNexus.Data.Assets
             {
                 case AssetType.Blueprint:
                     return GetAssets("blueprints", _parkitect.Paths.GetAssetPath(AssetType.Blueprint), "*.png", ResolveBlueprintData, AssetType.Blueprint);
-                case AssetType.Savegame:
-                    return GetAssets("savegames", _parkitect.Paths.GetAssetPath(AssetType.Savegame), "*.txt", ResolveSavegameData, AssetType.Savegame);
+                case AssetType.Park:
+                    return GetAssets("savegames", _parkitect.Paths.GetAssetPath(AssetType.Park), "*.txt", ResolveSavegameData, AssetType.Park);
                 case AssetType.Mod:
                     throw new NotImplementedException();
                 default:
@@ -57,8 +57,8 @@ namespace ParkitectNexus.Data.Assets
             {
                 case AssetType.Blueprint:
                     return Directory.GetFiles(_parkitect.Paths.GetAssetPath(AssetType.Blueprint), "*.png", SearchOption.AllDirectories).Length;
-                case AssetType.Savegame:
-                    return Directory.GetFiles(_parkitect.Paths.GetAssetPath(AssetType.Savegame), "*.txt", SearchOption.AllDirectories).Length;
+                case AssetType.Park:
+                    return Directory.GetFiles(_parkitect.Paths.GetAssetPath(AssetType.Park), "*.txt", SearchOption.AllDirectories).Length;
                 case AssetType.Mod:
                     throw new NotImplementedException();
                 default:
@@ -112,7 +112,7 @@ namespace ParkitectNexus.Data.Assets
 
         private AssetCachedData ResolveSavegameData(string relativePath)
         {
-            var path = Path.Combine(_parkitect.Paths.GetAssetPath(AssetType.Savegame), relativePath);
+            var path = Path.Combine(_parkitect.Paths.GetAssetPath(AssetType.Park), relativePath);
             var reader = new SavegameReader();
             var data = new AssetCachedData();
 
@@ -151,7 +151,7 @@ namespace ParkitectNexus.Data.Assets
             switch (asset.ApiAsset.Type)
             {
                 case AssetType.Blueprint:
-                case AssetType.Savegame:
+                case AssetType.Park:
                     // Create the directory where the asset should be stored and create a path to where the asset should be stored.
                     var storagePath = _parkitect.Paths.GetAssetPath(asset.ApiAsset.Type);
                     var assetPath = Path.Combine(storagePath, asset.FileName);

--- a/src/ParkitectNexus.Data/Assets/RemoteAssetRepository.cs
+++ b/src/ParkitectNexus.Data/Assets/RemoteAssetRepository.cs
@@ -106,7 +106,7 @@ namespace ParkitectNexus.Data.Assets
             switch (asset.Type)
             {
                 case AssetType.Blueprint:
-                case AssetType.Savegame:
+                case AssetType.Park:
                     return new DownloadInfo(asset.DownloadUrl, null, null);
                 case AssetType.Mod:
                     var repoUrl = ((await asset.GetResource()) as ApiModResource).Source;

--- a/src/ParkitectNexus.Data/Game/Base/BaseParkitectPaths.cs
+++ b/src/ParkitectNexus.Data/Game/Base/BaseParkitectPaths.cs
@@ -28,7 +28,7 @@ namespace ParkitectNexus.Data.Game.Base
             {
                 case AssetType.Blueprint:
                     return GetPathInSavesFolder("Saves\\Blueprints", true);
-                case AssetType.Savegame:
+                case AssetType.Park:
                     return GetPathInSavesFolder("Saves\\Savegames", true);
                 case AssetType.Mod:
                     return GetPathInSavesFolder("pnmods", true);


### PR DESCRIPTION
I replaced Savegame with Park as can seen by this chunk of json. You are trying to parse the object based on the type, but the type listed by the API is park and not Savegame. The problem with this is that the actual save will never actually load and end up blocking the queue. 


```
{
  "data": {
    "type": "park",
    "identifier": "12124527df",
    "name": "The Four",
    "description": "This park is just for this four rollercoasters. i thought it was beter to made a park blueprint than the four rolleroaster in single blueprint apart from each other. I hope you like it.\r\n",
    "thumbnail": {
      "id": 2377,
      "api_url": "http:\/\/staging.parkitectnexus.com\/api\/resources\/images\/2377",
      "url": "http:\/\/media.staging.parkitectnexus.com\/image\/90668b9b57f822f0015db7cd4c2b60efb6203ac1.jpg"
    },
    "album": [
      {
        "id": 2379,
        "api_url": "http:\/\/staging.parkitectnexus.com\/api\/resources\/images\/2379",
        "url": "http:\/\/media.staging.parkitectnexus.com\/image\/9b331ec841ba1ac33ae4aaba01a97b422c84279a.jpg"
      },
      {
        "id": 2380,
        "api_url": "http:\/\/staging.parkitectnexus.com\/api\/resources\/images\/2380",
        "url": "http:\/\/media.staging.parkitectnexus.com\/image\/0a19e033ec8277c6684d5d2762f83301bfdc2d02.jpg"
      },
      {
        "id": 2381,
        "api_url": "http:\/\/staging.parkitectnexus.com\/api\/resources\/images\/2381",
        "url": "http:\/\/media.staging.parkitectnexus.com\/image\/af41f2302aa0eebc675f92cc6535038e785f9433.jpg"
      }
    ],
    "tags": [
      
    ],
    "user": "http:\/\/staging.parkitectnexus.com\/api\/users\/e83d72d4e8",
    "resource": {
      "id": 316,
      "api_url": "http:\/\/staging.parkitectnexus.com\/api\/resources\/parks\/316"
    },
    "url": "http:\/\/staging.parkitectnexus.com\/assets\/12124527df\/the-four",
    "dependencies": [
      
    ],
    "download_url": "http:\/\/staging.parkitectnexus.com\/download\/12124527df",
    "created_at": "2016-01-20 12:38:35",
    "updated_at": "2016-01-28 07:50:24"
  }
}
```