### PR TITLE
Usage of https instead of http to connect to ParkitectNexus

### DIFF
--- a/src/ParkitectNexus.Data/Web/Website.cs
+++ b/src/ParkitectNexus.Data/Web/Website.cs
@@ -26,7 +26,7 @@ namespace ParkitectNexus.Data.Web
 #if DEBUG
         private const string WebsiteUrl = "http://{0}dev.parkitectnexus.com/{1}";
 #else
-        private const string WebsiteUrl = "http://{0}parkitectnexus.com/{1}";
+        private const string WebsiteUrl = "https://{0}parkitectnexus.com/{1}";
 #endif
 
         /// <summary>


### PR DESCRIPTION
That's only the case for the RELEASE build (parkitectnexus.com and client.parkitectnexus.com).
dev.parkitectnexus.com isn't available over https so no change for DEBUG build.