### PR TITLE
Fixed: Mod can be compiled with assemblies that are not available ingame

### DIFF
--- a/src/ParkitectNexus.Data/Assets/Modding/ModCompiler.cs
+++ b/src/ParkitectNexus.Data/Assets/Modding/ModCompiler.cs
@@ -26,23 +26,6 @@ namespace ParkitectNexus.Data.Assets.Modding
 {
     public class ModCompiler : IModCompiler
     {
-        /// <summary>
-        ///     Assemblies provided by the mono runtime.
-        /// </summary>
-        private static readonly string[] SystemAssemblies =
-        {
-            "System", "System.Core", "System.Data", "System.Xml",
-            "System.Xml.Linq", "System.Data.DataSetExtensions", "System.Net.Http"
-        };
-
-        /// <summary>
-        ///     References ignored during compilation.
-        /// </summary>
-        private static readonly string[] IgnoredAssemblies =
-        {
-            "Microsoft.CSharp"
-        };
-
         private readonly ILogger _log;
         private readonly IParkitect _parkitect;
 
@@ -270,27 +253,13 @@ namespace ParkitectNexus.Data.Assets.Modding
 
             var dllName = $"{assemblyName}.dll";
 
-            if (SystemAssemblies.Contains(assemblyName))
-                return dllName;
-
-            if (IgnoredAssemblies.Contains(assemblyName))
-                return null;
-
-//            var modPath = Path.Combine(InstallationPath, BaseDir ?? "", dllName);
-//            if (File.Exists(Path.Combine(modPath)))
-//                return modPath;
-
             var managedAssemblyNames =
                 Directory.GetFiles(_parkitect.Paths.DataManaged, "*.dll").Select(Path.GetFileName).ToArray();
 
             if (managedAssemblyNames.Contains(dllName))
                 return Path.Combine(_parkitect.Paths.DataManaged, dllName);
 
-//            if (SystemAssemblies.Contains(assemblyName))
-//                return dllName;
-
             return null;
-            //throw new Exception($"Failed to resolve referenced assembly '{assemblyName}'");
         }
     }
 }


### PR DESCRIPTION
System.Data, System.Xml.Linq, System.Data.DataSetExtensions and System.Net.Http aren't loaded by Parkitect but are used by the ParkitectNexus mod compiler. If something inside one of these assemblies is used in a mod, the mod compiles but throws an exception when used: "Could not load file or assembly 'System.Xml.Linq ...".

The assemblies used by Parkitect are in /Parkitect_Data/Managed. The ModCompiler already scans for assemblies in this directory. Therefore the ModCompiled doesn't have to treat System, System.Core and System.Xml extra: It doesn't matter if the compiler uses the assemblies installed on the system or the assemblies from Parkitect. Consequently the full SystemAssemblies array can be removed.

Additionally IgnoredAssemblies was removed too: Assemblies that aren't used by the code are automatically ignored during compilation. In fact "Microsoft.CSharp" doesn't even get resolve because it isn't a dll inside the /Parkitect_Data/Managed folder.



Note: This is a breaking change: Previously a mod could still contain code that uses stuff from "System.Data, System.Xml.Linq, System.Data.DataSetExtensions, System.Net.Http" -- unless these code parts get loaded (and therefore one of the missing assemblies) the Mod doesn't fail. With the changes in this commit the Mod doesn't even compile. But since those parts can't only "live" in the Mod as dead code and cannot be used, I think a fast fail during compilation is useful to indicate a wrong way. And additional an error while compiling is certainly better than a runtime error.