### PR TITLE
fixed: Loading of mod fails if Path and/or Identifier has no setter

### DIFF
--- a/src/ParkitectNexus.Mod.ModLoader/ModLoader.cs
+++ b/src/ParkitectNexus.Mod.ModLoader/ModLoader.cs
@@ -58,8 +58,14 @@ namespace ParkitectNexus.Mod.ModLoader
                     typeof (T), new Type[0], null);
 
             if (property != null)
-                property.SetValue(@object, value, BindingFlags.NonPublic | BindingFlags.Public, null, null,
-                    CultureInfo.CurrentCulture);
+            {
+                var setter = property.GetSetMethod(true);
+                if (setter != null)
+                {
+                    setter.Invoke(@object, BindingFlags.NonPublic | BindingFlags.Public, null, new object[] {value},
+                                    CultureInfo.CurrentCulture);
+                }
+            }
         }
 
         private static void LogToMod(string folder, string level, string format, params object[] args)


### PR DESCRIPTION
The [docs](https://parkitectnexus.com/modding-wiki/the-imod-interface#parkitectnexus-additions) say the setters are optional, but the loading of a mod fails when at least one of `Path` and `Identifier` exists but doesn't provide a setter ("Fatal: Exception during loading: Set Method not found for 'Path'.").